### PR TITLE
Fix `ldd 32-bit-binary` does not work on 64-bit host on arm32.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
         - |-
           sudo apt-get -yq install \
             crossbuild-essential-armhf \
-            libc6:armhf
+            libc6-dev:armhf
     # IBM, PowerPC, 64-bit, Little-endian
     - name: ppc64le
       arch: ppc64le

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,6 @@ clean :
 test : all
 	file $(TARGET)
 	ls -l $(TARGET)
+	ldd $(TARGET)
 	$(TARGET)
 .PHONY : test


### PR DESCRIPTION
I added glib6-dev as a trial. But it still has the issue.

The result `interpreter /lib/ld-` by `ldd` is weird.

```
$ $SETARCH make $JOBS test
Switching on ADDR_LIMIT_32BIT.
arm-linux-gnueabihf-gcc  -o bin/hello src/main.c
file bin/hello
bin/hello: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-, for GNU/Linux 3.2.0, BuildID[sha1]=f861d0ce624202c2ae8083c362e1d1c4e82b15cd, not stripped
ls -l bin/hello
-rwxr-xr-x 1 travis travis 8436 Nov 24 21:57 bin/hello
ldd bin/hello
	not a dynamic executable
```
