### PR TITLE
Remove branches syntax for testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,3 @@ before_script:
   - $CC --version
 script:
   - $SETARCH make $JOBS test
-branches:
-  except:
-    # Enable branches except the working in progress branchs "wip/"
-    - /^wip\//


### PR DESCRIPTION
Test the default behavior of Travis without `branches` syntax.
